### PR TITLE
[FIX] advance_clearing - return advance with budget

### DIFF
--- a/budget_control_advance_clearing/models/__init__.py
+++ b/budget_control_advance_clearing/models/__init__.py
@@ -2,5 +2,6 @@
 from . import advance_budget_move
 from . import budget_period
 from . import budget_control
+from . import account_move_line
 from . import hr_expense
 from . import budget_commit_forward

--- a/budget_control_advance_clearing/models/account_move_line.py
+++ b/budget_control_advance_clearing/models/account_move_line.py
@@ -1,0 +1,31 @@
+# Copyright 2020 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def _hook_advance_extension(self, expense):
+        self.ensure_one()
+        res = super()._hook_advance_extension(expense)
+        ParcialReconcile = self.env["account.partial.reconcile"]
+        # Return Advance should uncommit
+        reconciles = ParcialReconcile.search([("debit_move_id", "=", self.id)])
+        for reconcile in reconciles:
+            expense.commit_budget(
+                reverse=True,
+                amount_currency=reconcile.debit_amount_currency,
+                move_line_id=reconcile.id,
+            )
+        return res
+
+    def remove_move_reconcile(self):
+        """Trigger recompute budget move on Advance,
+        User can reset to draft payment return advance and
+        it should be compute budget again.
+        """
+        expense_id = self.matched_debit_ids.debit_move_id.expense_id
+        res = super().remove_move_reconcile()
+        expense_id.sheet_id.recompute_budget_move()
+        return res

--- a/budget_control_expense/models/account_move_line.py
+++ b/budget_control_expense/models/account_move_line.py
@@ -6,6 +6,10 @@ from odoo import models
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
+    def _hook_advance_extension(self, expense):
+        self.ensure_one()
+        return
+
     def uncommit_expense_budget(self):
         """For vendor bill in valid state, do uncommit for related expense."""
         Expense = self.env["hr.expense"]
@@ -20,6 +24,7 @@ class AccountMoveLine(models.Model):
                         continue
                     # Also test for future advance extension, never uncommit for advance
                     if hasattr(expense, "advance") and expense["advance"]:
+                        ml._hook_advance_extension(expense)
                         continue
                     expense.commit_budget(reverse=True, move_line_id=ml.id)
                 else:  # Cancel or draft, not commitment line


### PR DESCRIPTION
[BUG]
return advance and recompute budget, Line return advance on budget move not recompute

Step to error
1. Create advance until register payment process
2. Click `Return Advance` partial or full payment
3. Budget Move will `credit` return advance is correct
![Selection_001](https://user-images.githubusercontent.com/20896369/147544954-b5696dc2-0046-4312-baf3-807562d0e0a4.png)

4. Click `Recompute` on advance again
5. It will recompute only debit
![Selection_002](https://user-images.githubusercontent.com/20896369/147545061-51dbed0b-b375-4d47-aa02-a5ab37a8a9b9.png)


This PR solved this issue and support case reset to draft on payment (return advance).
cc: @kittiu 
