### PR TITLE
[FIX] not_affect_budget field and new field name on adjustment

### DIFF
--- a/budget_control/models/budget_move_adjustment.py
+++ b/budget_control/models/budget_move_adjustment.py
@@ -109,6 +109,7 @@ class BudgetMoveAdjustmentItem(models.Model):
         ondelete="cascade",
         index=True,
     )
+    name = fields.Char(string="Description")
     budget_move_ids = fields.One2many(
         comodel_name="account.budget.move",
         inverse_name="adjust_item_id",
@@ -148,6 +149,7 @@ class BudgetMoveAdjustmentItem(models.Model):
     @api.onchange("product_id")
     def _onchange_product_id(self):
         self.account_id = self.product_id._get_product_accounts()["expense"]
+        self.name = self.product_id.name
 
     @api.depends("amount")
     def _compute_amount_balance(self):

--- a/budget_control/report/budget_monitor_report.py
+++ b/budget_control/report/budget_monitor_report.py
@@ -61,7 +61,7 @@ class BudgetMonitorReport(models.Model):
     @property
     def _table_query(self):
         return """
-            select a.*, d.id as date_range_id, p.id as budget_period_id
+            select a.*, p.id as budget_period_id
             from ({}) a
             left outer join date_range d
                 on a.date between d.date_start and d.date_end
@@ -111,7 +111,8 @@ class BudgetMonitorReport(models.Model):
                 a.reference as reference,
                 null::char as budget_state,
                 a.fwd_commit,
-                1::boolean as active
+                1::boolean as active,
+                null::integer as date_range_id
                 """
                 % (amount_type[:1], res_model, res_field, amount_type)
             }
@@ -152,7 +153,8 @@ class BudgetMonitorReport(models.Model):
             b.name as reference,
             b.state as budget_state,
             0::boolean as fwd_commit,
-            a.active as active
+            a.active as active,
+            a.date_range_id as date_range_id
         """
         }
 
@@ -192,5 +194,4 @@ class BudgetMonitorReport(models.Model):
         )
 
     def _get_where_sql(self):
-        """ Hook """
-        return ""
+        return "where (d.id = a.date_range_id or a.date_range_id is null)"

--- a/budget_control/views/account_move_views.xml
+++ b/budget_control/views/account_move_views.xml
@@ -29,6 +29,27 @@
                 <field name="auto_adjust_date_commit" optional="hide" />
                 <field name="date_commit" optional="hide" />
             </xpath>
+            <xpath
+                expr="//page[@id='aml_tab']/field[@name='line_ids']/tree/field[@name='analytic_account_id']"
+                position="attributes"
+            >
+                <attribute name="optional">show</attribute>
+            </xpath>
+            <xpath
+                expr="//page[@id='aml_tab']/field[@name='line_ids']/tree/field[@name='analytic_account_id']"
+                position="after"
+            >
+                <field
+                    name="json_budget_popover"
+                    optional="show"
+                    nolabel="1"
+                    string="Budget Figure"
+                    width="10px"
+                    widget="popover_widget"
+                    attrs="{'invisible': [('analytic_account_id', '=', False)]}"
+                    groups="budget_control.group_budget_control_user"
+                />
+            </xpath>
             <xpath expr="/form/sheet/notebook/page[last()]" position="after">
                 <page
                     string="Budget Commitment"

--- a/budget_control/views/budget_move_adjustment_view.xml
+++ b/budget_control/views/budget_move_adjustment_view.xml
@@ -127,7 +127,8 @@
                                     <field
                                         name="analytic_tag_ids"
                                         widget="many2many_tags"
-                                        optional="hide"
+                                        optional="show"
+                                        groups="analytic.group_analytic_tags"
                                     />
                                     <field name="amount" />
                                     <field name="amount_commit" optional="hide" />
@@ -145,13 +146,10 @@
                                             <field
                                                 name="analytic_tag_ids"
                                                 widget="many2many_tags"
-                                                optional="hide"
+                                                groups="analytic.group_analytic_tags"
                                             />
                                             <field name="amount" />
-                                            <field
-                                                name="amount_commit"
-                                                optional="hide"
-                                            />
+                                            <field name="amount_commit" />
                                         </group>
                                     </group>
                                 </form>

--- a/budget_control/views/budget_move_adjustment_view.xml
+++ b/budget_control/views/budget_move_adjustment_view.xml
@@ -111,6 +111,7 @@
                                 >
                                     <field name="adjust_type" />
                                     <field name="product_id" optional="hide" />
+                                    <field name="name" optional="show" />
                                     <field name="account_id" optional="show" />
                                     <field name="analytic_account_id" />
                                     <field
@@ -136,6 +137,7 @@
                                         <group>
                                             <field name="adjust_type" />
                                             <field name="product_id" />
+                                            <field name="name" />
                                             <field name="account_id" />
                                         </group>
                                         <group>


### PR DESCRIPTION
What's new
- [x] Support not_affect_budget default following journal when create from other module or create direct
- [x] Add name / Security analytic tag on adjustment budget move line
- [x] Add json budget (Figure) on journal items
- [x] Fix bug monitor spend amount * 2

----------------------------------------------------------

Step Bug
1. Create Date Range (Period and Year)
![Selection_007](https://user-images.githubusercontent.com/20896369/148636650-7de20c81-1c00-4e64-a27b-d7077737a410.png)

2. Budget Period -> use Period (or Year)
![Selection_008](https://user-images.githubusercontent.com/20896369/148636660-040a65d7-e798-40b7-bfab-167af4cd4317.png)


3. Generate budget control -> add plan value
![Selection_009](https://user-images.githubusercontent.com/20896369/148636680-955671e4-37fb-4540-834a-024caba1d3d9.png)

or you can see on budget monitoring

![Selection_010](https://user-images.githubusercontent.com/20896369/148636668-68e78dc0-b71b-454b-9489-a762a8b48040.png)


**[FIX]**
Filter domain date range following budget period plan type