### PR TITLE
[FIX] budget_control: check date commit only the can_commit lines

### DIFF
--- a/budget_control/models/base_budget_move.py
+++ b/budget_control/models/base_budget_move.py
@@ -430,7 +430,8 @@ class BudgetDoclineMixin(models.AbstractModel):
             "force_commit"
         ):  # precommit case
             self._set_date_commit()
-            self._check_date_commit()  # Testing only, can be removed when stable
+            if self.can_commit:  # Check only the can_commit lines
+                self._check_date_commit()  # Testing only, can be removed when stable
 
     def _check_date_commit(self):
         """ Commit date must inline with analytic account """

--- a/budget_control/models/budget_control.py
+++ b/budget_control/models/budget_control.py
@@ -547,12 +547,8 @@ class BudgetControl(models.Model):
         ctx = self.env.context.copy()
         ctx.update({"create": False, "edit": False})
         items = self.transfer_item_ids
-        list_view = self.env.ref(
-            "budget_control_transfer.view_budget_transfer_item_tree"
-        ).id
-        form_view = self.env.ref(
-            "budget_control_transfer.view_budget_transfer_item_form"
-        ).id
+        list_view = self.env.ref("budget_control.view_budget_transfer_item_tree").id
+        form_view = self.env.ref("budget_control.view_budget_transfer_item_form").id
         return {
             "name": _("Budget Transfer Items"),
             "type": "ir.actions.act_window",


### PR DESCRIPTION
In the pre-commit case, It should check date commit only the lines that `can_commit` = True.

From Issue #3830

CC: @kittiu @Saran440 