### PR TITLE
[FIX] default date_adjust on analytic and recompute advance clearing

### DIFF
--- a/budget_control/models/analytic_account.py
+++ b/budget_control/models/analytic_account.py
@@ -41,6 +41,7 @@ class AccountAnalyticAccount(models.Model):
     )
     auto_adjust_date_commit = fields.Boolean(
         string="Auto Adjust Commit Date",
+        default=True,
         help="Date From and Date To is used to determine valid date range of "
         "this analytic account when using with budgeting system. If this data range "
         "is setup, but the budget system set date_commit out of this date range "

--- a/budget_control/models/budget_commit_forward.py
+++ b/budget_control/models/budget_commit_forward.py
@@ -188,7 +188,7 @@ class BudgetCommitForward(models.Model):
         return res
 
     def _do_forward_commit(self, reverse=False):
-        """ Cerate carry forward budget move to all related documents """
+        """ Create carry forward budget move to all related documents """
         self = self.sudo()
         for rec in self:
             for line in rec.forward_line_ids:

--- a/budget_control_advance_clearing/models/__init__.py
+++ b/budget_control_advance_clearing/models/__init__.py
@@ -4,3 +4,4 @@ from . import budget_period
 from . import budget_control
 from . import hr_expense
 from . import budget_commit_forward
+from . import account_move

--- a/budget_control_advance_clearing/models/account_move.py
+++ b/budget_control_advance_clearing/models/account_move.py
@@ -9,9 +9,9 @@ class AccountMove(models.Model):
     def button_draft(self):
         """ Unlink return advance budget """
         res = super().button_draft()
-        payment = self.payment_id
-        if payment and payment.payment_type == "inbound":
-            budget_moves = self.env["advance.budget.move"]
-            return_advances = budget_moves.search([("move_id", "=", self.id)])
+        BudgetMove = self.env["advance.budget.move"]
+        moves_inbound = self.filtered(lambda l: l.payment_id.payment_type == "inbound")
+        if moves_inbound:
+            return_advances = BudgetMove.search([("move_id", "in", moves_inbound.ids)])
             return_advances.unlink()
         return res

--- a/budget_control_advance_clearing/models/account_move.py
+++ b/budget_control_advance_clearing/models/account_move.py
@@ -1,0 +1,17 @@
+# Copyright 2020 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def button_draft(self):
+        """ Unlink return advance budget """
+        res = super().button_draft()
+        payment = self.payment_id
+        if payment and payment.payment_type == "inbound":
+            budget_moves = self.env["advance.budget.move"]
+            return_advances = budget_moves.search([("move_id", "=", self.id)])
+            return_advances.unlink()
+        return res

--- a/budget_control_advance_clearing/models/hr_expense.py
+++ b/budget_control_advance_clearing/models/hr_expense.py
@@ -13,13 +13,17 @@ class HRExpenseSheet(models.Model):
     )
 
     def write(self, vals):
-        """ Clearing for its Advance """
+        """ Clearing for its Advance and Cancel payment expense """
+        cancel_state = self.state == "cancel" and True or False
         res = super().write(vals)
         if vals.get("state") in ("approve", "cancel"):
             # If this is a clearing, return commit to the advance
             advances = self.mapped("advance_sheet_id.expense_line_ids")
             if advances:
                 advances.recompute_budget_move()
+        # Support with module `hr_expense_cancel` if you change state cancel to post
+        if vals.get("state") == "post" and cancel_state:
+            self.mapped("expense_line_ids").recompute_budget_move()
         return res
 
 

--- a/budget_control_advance_clearing/models/hr_expense.py
+++ b/budget_control_advance_clearing/models/hr_expense.py
@@ -14,7 +14,7 @@ class HRExpenseSheet(models.Model):
 
     def write(self, vals):
         """ Clearing for its Advance and Cancel payment expense """
-        cancel_state = self.state == "cancel" and True or False
+        doc_cancel = self.filtered(lambda l: l.state == "cancel")
         res = super().write(vals)
         if vals.get("state") in ("approve", "cancel"):
             # If this is a clearing, return commit to the advance
@@ -22,8 +22,8 @@ class HRExpenseSheet(models.Model):
             if advances:
                 advances.recompute_budget_move()
         # Support with module `hr_expense_cancel` if you change state cancel to post
-        if vals.get("state") == "post" and cancel_state:
-            self.mapped("expense_line_ids").recompute_budget_move()
+        if vals.get("state") == "post" and doc_cancel:
+            doc_cancel.mapped("expense_line_ids").recompute_budget_move()
         return res
 
 


### PR DESCRIPTION
- Add default = True on field auto_adjust in analytic account
- [FIX] support with state expense change from cancel to other state
- [FIX] cancel return advance, budget not reverse commit

Step to error:
1. install module budget_control_advance_clearing, hr_expense_cancel
2. config expense cancel state back to `posted` (depend on https://github.com/OCA/hr-expense/pull/56)
![Selection_004](https://user-images.githubusercontent.com/20896369/160234102-36d144de-b63e-464b-bdff-624569a0d54b.png)
3. Create advance 2 lines and normal process to paid
![Selection_005](https://user-images.githubusercontent.com/20896369/160234173-3dad7b9c-c5a3-44e9-b84d-3fc9fdcaeb76.png)
4. Go to Invoicing > Vendors > Payments
5. Select payment that create from advance > Reset To Draft > Cancel
6. ---- **Back to advance document - state back to posted but budget will unlink** ----
![Selection_006](https://user-images.githubusercontent.com/20896369/160234271-18417f33-7d7e-4d28-b512-72a60feb64c7.png)
7. ---- Register Payment again - **it will commit budget 1 line only** ----
![Selection_007](https://user-images.githubusercontent.com/20896369/160234313-bb3a5b8c-745b-4b2b-af76-a21ff20618ae.png)


-----------------------------------------------------

Step to error cancel return not reverse commit:
1. Create advance and normal process to paid
2. Return advance
3. Go to Invoicing > Customers > Payments > select payment from return advance
4. Reset to Draft > advance will return Amount to clear **BUT** Advance commit not reverse commit return advance
![Selection_004](https://user-images.githubusercontent.com/20896369/160264594-f1fbb8e7-14c4-439b-adb8-6eb7cc4ceb65.png)

Budget Commit will not equal amount to clear
I fixed by unlink commit return when reset to draft

@kittiu 